### PR TITLE
Strip debug

### DIFF
--- a/.github/bootstrap.sh
+++ b/.github/bootstrap.sh
@@ -128,6 +128,7 @@ for ((i = 0; i < ${#PLATFORMS[@]}; i += 2)); do
     done
 
     # FIXME: figure out how to make xcodebuild output the .a file directly. For now, we package it ourselves.
+    strip -S $DERIVED_DATA_PATH/Build/Intermediates.noindex/swift-syntax.build/$CONFIGURATION*/*.build/Objects-normal/$ARCH/Binary/*.o
     ar -crs "$LIBRARY_PATH" $DERIVED_DATA_PATH/Build/Intermediates.noindex/swift-syntax.build/$CONFIGURATION*/*.build/Objects-normal/$ARCH/Binary/*.o
 done
 

--- a/Package.swift
+++ b/Package.swift
@@ -10,8 +10,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "SwiftSyntaxWrapper",
-            url: "https://github.com/ordo-one/swift-syntax-xcframeworks/releases/download/600.0.1/SwiftSyntaxWrapper.xcframework.zip",
-            checksum: "324220ef6cbb1edfffa5cba4687eb79e9f2b43dc0301a613cc7a07defbccdce2"
+            url: "https://github.com/sjavora/swift-syntax-xcframeworks/releases/download/600.0.1/SwiftSyntaxWrapper.xcframework.zip",
+            checksum: "1fcd4a7b144284934801a67064e85d2641efd1128ef8efb42a51855f0d586329"
         ),
     ]
 )


### PR DESCRIPTION
When using prebuilt swift-syntax with swift package manager, a lot of errors show up like:

```
warning: (arm64) /Users/runner/work/swift-syntax-xcframeworks/swift-syntax-xcframeworks/derivedData/Build/Intermediates.noindex/swift-syntax.build/debug/SwiftBasicFormat.build/Objects-normal/arm64/BasicFormat.o unable to open object file: No such file or directory
warning: (arm64) /Users/runner/work/swift-syntax-xcframeworks/swift-syntax-xcframeworks/derivedData/Build/Intermediates.noindex/swift-syntax.build/debug/SwiftBasicFormat.build/Objects-normal/arm64/Syntax+Extensions.o unable to open object file: No such file or directory
warning: (arm64) /Users/runner/work/swift-syntax-xcframeworks/swift-syntax-xcframeworks/derivedData/Build/Intermediates.noindex/swift-syntax.build/debug/SwiftBasicFormat.build/Objects-normal/arm64/SyntaxProtocol+Formatted.o unable to open object file: No such file or directory
warning: (arm64) /Users/runner/work/swift-syntax-xcframeworks/swift-syntax-xcframeworks/derivedData/Build/Intermediates.noindex/swift-syntax.build/debug/SwiftBasicFormat.build/Objects-normal/arm64/Trivia+FormatExtensions.o unable to open object file: No such file or directory
warning: (arm64) /Users/runner/work/swift-syntax-xcframeworks/swift-syntax-xcframeworks/derivedData/Build/Intermediates.noindex/swift-syntax.build/debug/SwiftCompilerPlugin.build/Objects-normal/arm64/CompilerPlugin.o unable to open object file: No such file or directory
warning: (arm64) /Users/runner/work/swift-syntax-xcframeworks/swift-syntax-xcframeworks/derivedData/Build/Intermediates.noindex/swift-syntax.build/debug/SwiftCompilerPluginMessageHandling.build/Objects-normal/arm64/CompilerPluginMessageHandler.o unable to open object file: No such file or directory
warning: (arm64) /Users/runner/work/swift-syntax-xcframeworks/swift-syntax-xcframeworks/derivedData/Build/Intermediates.noindex/swift-syntax.build/debug/SwiftCompilerPluginMessageHandling.build/Objects-normal/arm64/Diagnostics.o unable to open object file: No such file or directory
```

When built by Xcode, this is stripped via `SWIFT_SERIALIZE_DEBUGGING_OPTIONS`; but stripping the binaries also removes the warning.